### PR TITLE
README: fix missing use of "r" and "phi" shorthands

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -264,7 +264,7 @@ The `stack <http://histbook.readthedocs.io/en/latest/plotting.html#histbook.vega
 
     >>> r = "sqrt(x**2 + y**2)"
     >>> phi = "arctan2(y, x)"
-    >>> hist.stack("arctan2(y, x)").area("sqrt(x**2+y**2)").to(canvas)
+    >>> hist.stack(phi).area(r).to(canvas)
 
 .. image:: docs/source/intro-4.png
 


### PR DESCRIPTION
I was reading the manual and found myself questioning where did the `phi` and `r` come from. Turns out the snippet where those are defined wasn't using them, so I just didn't notice them defined.